### PR TITLE
Adaptive max length to avoid truncation

### DIFF
--- a/python/dgml_utils/config.py
+++ b/python/dgml_utils/config.py
@@ -1,14 +1,14 @@
 TABLE_NAME = "{http://www.w3.org/1999/xhtml}table"
 STRUCTURE_KEY = "structure"
 
-DEFAULT_MIN_CHUNK_SIZE = 8  # Default length threshold for determining small chunks
+DEFAULT_MIN_CHUNK_LENGTH = 8  # Default length threshold for determining small chunks
 DEFAULT_SUBCHUNK_TABLES = False
 DEFAULT_TABLE_FORMAT_AS_TEXT = "grid"  # should be a valid format for the tabulate library
 DEFAULT_WHITESPACE_NORMALIZE_TEXT = True
 DEFAULT_INCLUDE_XML_TAGS = False
 DEFAULT_XML_HIERARCHY_LEVELS = 0
 DEFAULT_SKIP_XML_TAGS = ["chunk"]  # chunks that are skipped in the parent hierarchy and also not included inline in XML
-DEFAULT_MAX_TEXT_SIZE = 1024
+DEFAULT_MAX_TEXT_LENGTH = 1024
 
 NAMESPACES = {
     "docset": "http://www.docugami.com/2021/dgml/TaqiTest20231103/NDA",

--- a/python/dgml_utils/conversions.py
+++ b/python/dgml_utils/conversions.py
@@ -6,7 +6,7 @@ from dgml_utils.config import (
     DEFAULT_SKIP_XML_TAGS,
     DEFAULT_TABLE_FORMAT_AS_TEXT,
     DEFAULT_WHITESPACE_NORMALIZE_TEXT,
-    DEFAULT_MAX_TEXT_SIZE,
+    DEFAULT_MAX_TEXT_LENGTH,
     NAMESPACES,
     TABLE_NAME,
 )
@@ -75,16 +75,16 @@ def nth_ancestor(
     node,
     n: int,
     skip_tags=DEFAULT_SKIP_XML_TAGS,
-    max_text_size=DEFAULT_MAX_TEXT_SIZE,
+    max_text_length=DEFAULT_MAX_TEXT_LENGTH,
     whitespace_normalize=DEFAULT_WHITESPACE_NORMALIZE_TEXT,
 ):
     """
-    Finds the nth ancestor of a given lxml node, skipping nodes with tags in skip_tags and considering text size limit.
+    Finds the nth ancestor of a given lxml node, skipping nodes with tags in skip_tags and considering text length limit.
 
     :param node: The lxml node from which to find the ancestor
     :param n: The number of ancestors to go up the XML tree. If n <= 0, the node itself is returned.
     :param skip_tags: Tags to skip when counting ancestors
-    :param max_text_size: The maximum size of text allowed before stopping the search
+    :param max_text_length: The maximum length of text allowed before stopping the search
     :param whitespace_normalize: Whether to normalize whitespace in text node processing
     :return: The nth ancestor lxml node or the node itself if n <= 0 or no ancestors are found
 
@@ -118,7 +118,7 @@ def nth_ancestor(
             filtered_ancestors = [anc for anc in all_ancestors if clean_tag(anc) not in skip_tags]
 
             for i, ancestor in enumerate(filtered_ancestors):
-                if len(text_node_to_text(ancestor, whitespace_normalize)) > max_text_size or i + 1 == n:
+                if len(text_node_to_text(ancestor, whitespace_normalize)) > max_text_length or i + 1 == n:
                     return ancestor
 
     # If no ancestors are found, return the node itself
@@ -153,7 +153,7 @@ def simplified_xml(
     whitespace_normalize=DEFAULT_WHITESPACE_NORMALIZE_TEXT,
     skip_tags=DEFAULT_SKIP_XML_TAGS,
     xml_hierarchy_levels=DEFAULT_XML_HIERARCHY_LEVELS,
-    max_text_size=DEFAULT_MAX_TEXT_SIZE,
+    max_text_length=DEFAULT_MAX_TEXT_LENGTH,
 ) -> str:
     """
     Renders the given node (or parent at specified hierarchy level) to simplified XML
@@ -163,7 +163,7 @@ def simplified_xml(
     :param whitespace_normalize: Whether to normalize whitespace in text node processing
     :param skip_tags: Tags to skip when counting ancestors
     :param xml_hierarchy_levels: The number of hierarchy levels to go up from the node
-    :param max_text_size: The maximum size of chunk returned (by text)
+    :param max_text_length: The maximum length of chunk returned (by text)
     :return: Simplified XML string
 
     >>> nsmap = {'ns': 'http://test.com'}
@@ -171,7 +171,7 @@ def simplified_xml(
     >>> child = root.find('.//ns:child', namespaces=nsmap)
     >>> print(simplified_xml(child, skip_tags=['skip'], xml_hierarchy_levels=100))
     <root><parent><child>Text</child></parent></root>
-    >>> print(simplified_xml(child, skip_tags=['skip'], xml_hierarchy_levels=100, max_text_size=9))
+    >>> print(simplified_xml(child, skip_tags=['skip'], xml_hierarchy_levels=100, max_text_length=9))
     <root><pa
     """
     if node is None:
@@ -181,7 +181,7 @@ def simplified_xml(
         node,
         n=xml_hierarchy_levels,
         skip_tags=skip_tags,
-        max_text_size=max_text_size,
+        max_text_length=max_text_length,
         whitespace_normalize=whitespace_normalize,
     )
     simplified_node = simplified_element(node)
@@ -194,4 +194,4 @@ def simplified_xml(
 
     if whitespace_normalize:
         xml = " ".join(xml.split()).strip()
-    return xml.strip()[:max_text_size].strip()
+    return xml.strip()[:max_text_length].strip()

--- a/python/dgml_utils/conversions.py
+++ b/python/dgml_utils/conversions.py
@@ -192,6 +192,10 @@ def simplified_xml(
     Test walking up hierarchy level with skipping but early stopping due to max text length
     >>> print(simplified_xml(child, skip_tags=['skip'], xml_hierarchy_levels=100, max_text_length=40))
     <child>Text</child>
+
+    Test forced truncation of current node if it is large
+    >>> print(simplified_xml(child, max_text_length=9))
+    <child>Te
     """
     if node is None:
         return ""

--- a/python/dgml_utils/segmentation.py
+++ b/python/dgml_utils/segmentation.py
@@ -3,11 +3,11 @@ from typing import List, Optional
 
 from dgml_utils.config import (
     DEFAULT_INCLUDE_XML_TAGS,
-    DEFAULT_MIN_CHUNK_SIZE,
+    DEFAULT_MIN_CHUNK_LENGTH,
     DEFAULT_SUBCHUNK_TABLES,
     DEFAULT_WHITESPACE_NORMALIZE_TEXT,
     DEFAULT_XML_HIERARCHY_LEVELS,
-    DEFAULT_MAX_TEXT_SIZE,
+    DEFAULT_MAX_TEXT_LENGTH,
     STRUCTURE_KEY,
     TABLE_NAME,
 )
@@ -41,12 +41,12 @@ def has_structural_children(element) -> bool:
 
 def get_leaf_structural_chunks(
     element,
-    min_chunk_size=DEFAULT_MIN_CHUNK_SIZE,
+    min_chunk_length=DEFAULT_MIN_CHUNK_LENGTH,
     whitespace_normalize_text=DEFAULT_WHITESPACE_NORMALIZE_TEXT,
     sub_chunk_tables=DEFAULT_SUBCHUNK_TABLES,
     include_xml_tags=DEFAULT_INCLUDE_XML_TAGS,
     xml_hierarchy_levels=DEFAULT_XML_HIERARCHY_LEVELS,
-    max_text_size=DEFAULT_MAX_TEXT_SIZE,
+    max_text_length=DEFAULT_MAX_TEXT_LENGTH,
 ) -> List[Chunk]:
     """Returns all leaf structural nodes in the given element, combining small chunks with following structural nodes."""
     leaf_chunks: List[Chunk] = []
@@ -63,7 +63,7 @@ def get_leaf_structural_chunks(
                 node,
                 whitespace_normalize=whitespace_normalize_text,
                 xml_hierarchy_levels=xml_hierarchy_levels,
-                max_text_size=max_text_size,
+                max_text_length=max_text_length,
             )
         elif table_node:
             node_text = xhtml_table_to_text(node, whitespace_normalize=whitespace_normalize_text)
@@ -105,7 +105,7 @@ def get_leaf_structural_chunks(
                 chunk = prepended_small_chunk + chunk
                 prepended_small_chunk = None  # clear
 
-            if len(chunk.text) < min_chunk_size or node.attrib.get(STRUCTURE_KEY) == "lim":
+            if len(chunk.text) < min_chunk_length or node.attrib.get(STRUCTURE_KEY) == "lim":
                 # Prepend small chunks or list item markers to the following chunk
                 prepended_small_chunk = chunk
             else:
@@ -126,20 +126,20 @@ def get_leaf_structural_chunks(
 
 def get_leaf_structural_chunks_str(
     dgml: str,
-    min_chunk_size=DEFAULT_MIN_CHUNK_SIZE,
+    min_chunk_length=DEFAULT_MIN_CHUNK_LENGTH,
     whitespace_normalize_text=DEFAULT_WHITESPACE_NORMALIZE_TEXT,
     sub_chunk_tables=DEFAULT_SUBCHUNK_TABLES,
     include_xml_tags=DEFAULT_INCLUDE_XML_TAGS,
     xml_hierarchy_levels=DEFAULT_XML_HIERARCHY_LEVELS,
-    max_text_size=DEFAULT_MAX_TEXT_SIZE,
+    max_text_length=DEFAULT_MAX_TEXT_LENGTH,
 ) -> List[Chunk]:
     root = etree.fromstring(dgml)
     return get_leaf_structural_chunks(
         element=root,
-        min_chunk_size=min_chunk_size,
+        min_chunk_length=min_chunk_length,
         whitespace_normalize_text=whitespace_normalize_text,
         sub_chunk_tables=sub_chunk_tables,
         include_xml_tags=include_xml_tags,
         xml_hierarchy_levels=xml_hierarchy_levels,
-        max_text_size=max_text_size,
+        max_text_length=max_text_length,
     )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dgml-utils"
-version = "0.0.8"
+version = "0.0.9"
 description = "Python utilities to work with the Docugami Markup Language (DGML) format."
 authors = ["Docugami <contact@docugami.com>"]
 license = "MIT"

--- a/python/tests/test_segmentation.py
+++ b/python/tests/test_segmentation.py
@@ -4,7 +4,7 @@ import pytest
 import yaml
 
 from dgml_utils.segmentation import (
-    DEFAULT_MIN_CHUNK_SIZE,
+    DEFAULT_MIN_CHUNK_LENGTH,
     DEFAULT_SUBCHUNK_TABLES,
     DEFAULT_INCLUDE_XML_TAGS,
     DEFAULT_XML_HIERARCHY_LEVELS,
@@ -16,7 +16,7 @@ from dgml_utils.segmentation import (
 class SegmentationTestData:
     input_file: Path
     output_file: Path
-    min_chunk_size: int = DEFAULT_MIN_CHUNK_SIZE
+    min_chunk_length: int = DEFAULT_MIN_CHUNK_LENGTH
     sub_chunk_tables: bool = DEFAULT_SUBCHUNK_TABLES
     include_xml_tags: bool = DEFAULT_INCLUDE_XML_TAGS
     xml_hierarchy_levels: int = DEFAULT_XML_HIERARCHY_LEVELS
@@ -37,7 +37,7 @@ SEGMENTATION_TEST_DATA: list[SegmentationTestData] = [
     SegmentationTestData(
         input_file=TEST_DATA_DIR / "simple/simple.xml",
         output_file=TEST_DATA_DIR / "simple/simple.normalized-chunks_all.yaml",
-        min_chunk_size=0,  # want all the chunks, regardless of size
+        min_chunk_length=0,  # want all the chunks, regardless of length
         sub_chunk_tables=True,  # want all cells inside tables chunked out
     ),
     SegmentationTestData(
@@ -47,7 +47,7 @@ SEGMENTATION_TEST_DATA: list[SegmentationTestData] = [
     SegmentationTestData(
         input_file=TEST_DATA_DIR / "article/Jane Doe.xml",
         output_file=TEST_DATA_DIR / "article/Jane Doe.normalized-chunks_all.yaml",
-        min_chunk_size=0,  # want all the chunks, regardless of size
+        min_chunk_length=0,  # want all the chunks, regardless of length
         sub_chunk_tables=True,  # want all cells inside tables chunked out
     ),
     SegmentationTestData(
@@ -67,7 +67,7 @@ def test_segmentation(test_data: SegmentationTestData):
         article_shaped_file_xml = input_file.read()
         chunks = get_leaf_structural_chunks_str(
             dgml=article_shaped_file_xml,
-            min_chunk_size=test_data.min_chunk_size,
+            min_chunk_length=test_data.min_chunk_length,
             sub_chunk_tables=test_data.sub_chunk_tables,
             include_xml_tags=test_data.include_xml_tags,
             xml_hierarchy_levels=test_data.xml_hierarchy_levels,


### PR DESCRIPTION
When walking up the XML hierarchy, we were not correctly stopping when an ancestor exceeded the specified max length. This was leading us to go over the limit when walking up the chain, then truncating the XML when returning, leading to context loss.

Fixed that, added more tests, and fixed naming of length (previously called size)